### PR TITLE
feat: add Python 3.15 support

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,6 +19,8 @@ jobs:
         - '3.13'
         - '3.14'
         - 3.14t
+        - '3.15'
+        - 3.15t
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -27,6 +29,7 @@ jobs:
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         version: 0.12.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes
 
 * Packaging cleanups and improvements.
 * Binary wheels now use ABI3.
+* Python 3.15 compatibility.
 
 2.6
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Libraries :: Python Modules"
 ]
 description = "Python module (in c) for siphash-2-4"

--- a/siphashc.c
+++ b/siphashc.c
@@ -24,9 +24,9 @@
 
 #define PY_SSIZE_T_CLEAN
 
+#include <Python.h>
 #include <stdlib.h>
 #include <string.h>
-#include <Python.h>
 #include "siphash/siphash.h"
 
 static PyObject *pysiphash(PyObject *self, PyObject *args) {


### PR DESCRIPTION
Python 3.15 defines feature-test macros through Python.h, so it must precede libc headers. Cover regular and free-threaded interpreters and advertise the supported version.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
