### PR TITLE
feat: prepare extension for ABI3T builds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,6 @@ Changes
 
 * Packaging cleanups and improvements.
 * Binary wheels now use ABI3.
-* Python 3.15 compatibility.
 
 2.6
 ---

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ import sysconfig
 
 from setuptools import Extension, setup
 
+free_threaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 define_macros = [("Py_LIMITED_API", "0x030A0000")]
 bdist_options = {"py_limited_api": "cp310"}
 
-# Free-threaded Python is not compatible with ABI3, see
-# https://github.com/python/cpython/issues/111506
-if sysconfig.get_config_var("Py_GIL_DISABLED"):
-    define_macros = []
+# Build version-specific free-threaded wheels until setuptools supports ABI3T.
+# https://github.com/pypa/setuptools/issues/5205
+if free_threaded:
+    define_macros = [("Py_GIL_DISABLED", "1")]
     bdist_options = {}
 
 setup(
@@ -21,7 +22,7 @@ setup(
             sources=["siphashc.c", "siphash/siphash.c"],
             language="c",
             define_macros=define_macros,
-            py_limited_api=True,
+            py_limited_api=not free_threaded,
         ),
     ],
     options={"bdist_wheel": bdist_options},

--- a/siphashc.c
+++ b/siphashc.c
@@ -69,6 +69,26 @@ static PyMethodDef siphashc_methods[] = {
     {NULL, NULL, 0, NULL} /* sentinel */
 };
 
+#ifdef Py_TARGET_ABI3T
+
+PyABIInfo_VAR(abi_info);
+
+static PySlot siphashc_slots[] = {
+    PySlot_STATIC_DATA(Py_mod_abi, &abi_info),
+    PySlot_STATIC_DATA(Py_mod_name, "siphashc"),
+    PySlot_STATIC_DATA(Py_mod_methods, siphashc_methods),
+    PySlot_STATIC_DATA(Py_mod_gil, Py_MOD_GIL_NOT_USED),
+    PySlot_END,
+};
+
+PyMODEXPORT_FUNC
+PyModExport_siphashc(void)
+{
+    return siphashc_slots;
+}
+
+#else
+
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "siphashc",
@@ -84,5 +104,17 @@ static struct PyModuleDef moduledef = {
 PyObject *
 PyInit_siphashc(void)
 {
-    return PyModule_Create(&moduledef);
+    PyObject *module = PyModule_Create(&moduledef);
+
+#ifdef Py_GIL_DISABLED
+    if (module != NULL &&
+            PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED) < 0) {
+        Py_DECREF(module);
+        return NULL;
+    }
+#endif
+
+    return module;
 }
+
+#endif

--- a/test_siphashc.py
+++ b/test_siphashc.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+import sysconfig
 import unittest
 
 import pytest
@@ -11,6 +13,14 @@ from siphashc import siphash
 
 class TestSiphashC(unittest.TestCase):
     """Test for siphashc module."""
+
+    @pytest.mark.skipif(
+        not sysconfig.get_config_var("Py_GIL_DISABLED"),
+        reason="requires free-threaded Python",
+    )
+    def test_gil_disabled(self: TestSiphashC) -> None:
+        """Test that importing the module does not enable the GIL."""
+        assert not sys._is_gil_enabled()  # noqa: SLF001
 
     def test_hash(self: TestSiphashC) -> None:
         """Test simple hashing."""


### PR DESCRIPTION
Python 3.15 requires slot-based module exports for ABI3T. Keep free-threaded wheels version-specific until setuptools gains native ABI3T tagging support.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
