### PR TITLE
fix: decode SipHash inputs portably

### DIFF
--- a/siphash/siphash.c
+++ b/siphash/siphash.c
@@ -4,7 +4,14 @@
 
 INLINE static uint64_t
 U8TO64_LE(const unsigned char *p) {
-    return *(const uint64_t *)p;
+    return ((uint64_t)p[0])
+        | ((uint64_t)p[1] << 8)
+        | ((uint64_t)p[2] << 16)
+        | ((uint64_t)p[3] << 24)
+        | ((uint64_t)p[4] << 32)
+        | ((uint64_t)p[5] << 40)
+        | ((uint64_t)p[6] << 48)
+        | ((uint64_t)p[7] << 56);
 }
 
 uint64_t

--- a/test_siphashc.py
+++ b/test_siphashc.py
@@ -116,8 +116,8 @@ class TestSiphashC(unittest.TestCase):
             0xE51B38608EF25F57,
             0x958A324CEB064572,
         ]
-        k = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
-        message = ""
+        k = bytes(range(16))
+        message = b""
         for i in range(64):
             assert siphash(k, message) == vectors[i]
-            message += chr(i)
+            message += bytes((i,))


### PR DESCRIPTION
Replace alignment-sensitive native loads with explicit little-endian decoding to avoid undefined behavior and keep hashes consistent across architectures.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
