### PR TITLE
perf: release GIL for large inputs

### DIFF
--- a/siphashc.c
+++ b/siphashc.c
@@ -29,7 +29,38 @@
 #include <string.h>
 #include "siphash/siphash.h"
 
+#define SIPHASH_GIL_THRESHOLD 8192
+
+static int get_immutable_data(
+        PyObject *object,
+        const char *argument_name,
+        const char **data,
+        Py_ssize_t *size) {
+    if (PyBytes_Check(object)) {
+        char *bytes_data;
+
+        if (PyBytes_AsStringAndSize(object, &bytes_data, size) < 0) {
+            return 0;
+        }
+        *data = bytes_data;
+        return 1;
+    }
+
+    if (PyUnicode_Check(object)) {
+        *data = PyUnicode_AsUTF8AndSize(object, size);
+        return *data != NULL;
+    }
+
+    PyErr_Format(
+        PyExc_TypeError,
+        "%s must be str or bytes",
+        argument_name);
+    return 0;
+}
+
 static PyObject *pysiphash(PyObject *self, PyObject *args) {
+    PyObject *key_object;
+    PyObject *plaintext_object;
     const char *key = NULL;
     Py_ssize_t key_sz;
     const char *plaintext = NULL;
@@ -37,8 +68,18 @@ static PyObject *pysiphash(PyObject *self, PyObject *args) {
     uint64_t hash;
 
     if (!PyArg_ParseTuple(
-            args, "s#s#:siphash",
-            &key, &key_sz, &plaintext, &plain_sz)) {
+            args, "OO:siphash",
+            &key_object, &plaintext_object)) {
+        return NULL;
+    }
+
+    /* Both objects own immutable storage and args keeps them alive. */
+    if (!get_immutable_data(key_object, "key", &key, &key_sz) ||
+            !get_immutable_data(
+                plaintext_object,
+                "plaintext",
+                &plaintext,
+                &plain_sz)) {
         return NULL;
     }
 
@@ -49,10 +90,26 @@ static PyObject *pysiphash(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+#ifdef Py_GIL_DISABLED
     hash = siphash(
-        (const unsigned char*)key,
-        (const unsigned char*)plaintext,
+        (const unsigned char *)key,
+        (const unsigned char *)plaintext,
         plain_sz);
+#else
+    if (plain_sz >= SIPHASH_GIL_THRESHOLD) {
+        Py_BEGIN_ALLOW_THREADS
+        hash = siphash(
+            (const unsigned char *)key,
+            (const unsigned char *)plaintext,
+            plain_sz);
+        Py_END_ALLOW_THREADS
+    } else {
+        hash = siphash(
+            (const unsigned char *)key,
+            (const unsigned char *)plaintext,
+            plain_sz);
+    }
+#endif
 
     return PyLong_FromUnsignedLongLong(hash);
 }

--- a/test_siphashc.py
+++ b/test_siphashc.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 import sys
 import sysconfig
+import threading
+import time
 import unittest
 
 import pytest
 
 from siphashc import siphash
+
+GIL_THRESHOLD = 8192
+GIL_TEST_ITERATIONS = 10_000
+
+
+class BytesSubclass(bytes):
+    """Bytes subclass used to verify accepted immutable inputs."""
+
+
+class StringSubclass(str):
+    """String subclass used to verify accepted immutable inputs."""
+
+    __slots__ = ()
 
 
 class TestSiphashC(unittest.TestCase):
@@ -29,6 +44,87 @@ class TestSiphashC(unittest.TestCase):
 
         result = siphash("0123456789ABCDEF", "a")
         assert result == 12398370950267227270  # noqa: PLR2004
+
+    def test_immutable_inputs(self: TestSiphashC) -> None:
+        """Test accepted immutable input types."""
+        expected = siphash(b"0123456789ABCDEF", b"a")
+
+        assert siphash("0123456789ABCDEF", "a") == expected
+        assert (
+            siphash(
+                BytesSubclass(b"0123456789ABCDEF"),
+                BytesSubclass(b"a"),
+            )
+            == expected
+        )
+        assert (
+            siphash(
+                StringSubclass("0123456789ABCDEF"),
+                StringSubclass("a"),
+            )
+            == expected
+        )
+
+    def test_rejects_other_inputs(self: TestSiphashC) -> None:
+        """Test rejection of mutable and generic buffer inputs."""
+        invalid_keys = (
+            bytearray(b"0123456789ABCDEF"),
+            memoryview(b"0123456789ABCDEF"),
+            object(),
+        )
+        invalid_plaintexts = (bytearray(b"a"), memoryview(b"a"), object())
+
+        for key in invalid_keys:
+            with pytest.raises(TypeError, match="key must be str or bytes"):
+                siphash(key, b"a")
+
+        for plaintext in invalid_plaintexts:
+            with pytest.raises(TypeError, match="plaintext must be str or bytes"):
+                siphash(b"0123456789ABCDEF", plaintext)
+
+    @pytest.mark.skipif(
+        bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
+        reason="requires a GIL-enabled Python",
+    )
+    def test_gil_release_threshold(self: TestSiphashC) -> None:
+        """Test that only inputs at or above the threshold release the GIL."""
+        counter = 0
+        ready = threading.Event()
+        stop = threading.Event()
+
+        def count_in_thread() -> None:
+            nonlocal counter
+            ready.set()
+            while not stop.is_set():
+                counter += 1
+                time.sleep(0)
+
+        thread = threading.Thread(target=count_in_thread)
+        previous_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1.0)
+        try:
+            thread.start()
+            assert ready.wait(timeout=5)
+
+            key = b"0123456789ABCDEF"
+            below_threshold = b"a" * (GIL_THRESHOLD - 1)
+            at_threshold = b"a" * GIL_THRESHOLD
+
+            before = counter
+            for _ in range(GIL_TEST_ITERATIONS):
+                siphash(key, below_threshold)
+            assert counter == before
+
+            before = counter
+            for _ in range(GIL_TEST_ITERATIONS):
+                siphash(key, at_threshold)
+            assert counter > before
+        finally:
+            stop.set()
+            sys.setswitchinterval(previous_interval)
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
 
     def test_errors(self: TestSiphashC) -> None:
         """Test error handling."""


### PR DESCRIPTION
Allow concurrent hashing above the measured 8 KiB threshold while requiring immutable str or bytes buffers so native reads remain stable.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
