### PR TITLE
perf: use FASTCALL for siphash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /MANIFEST
 /siphashc*.so
 *.py[co]
+/uv.lock

--- a/siphashc.c
+++ b/siphashc.c
@@ -30,6 +30,12 @@
 #include "siphash/siphash.h"
 
 #define SIPHASH_GIL_THRESHOLD 8192
+#if PY_VERSION_HEX < 0x030B0000
+#define SIPHASHC_PYC_FUNCTION_CAST(func) \
+    ((PyCFunction)(void (*)(void))(func))
+#else
+#define SIPHASHC_PYC_FUNCTION_CAST(func) _PyCFunction_CAST(func)
+#endif
 
 static int get_immutable_data(
         PyObject *object,
@@ -58,7 +64,10 @@ static int get_immutable_data(
     return 0;
 }
 
-static PyObject *pysiphash(PyObject *self, PyObject *args) {
+static PyObject *pysiphash(
+        PyObject *self,
+        PyObject *const *args,
+        Py_ssize_t nargs) {
     PyObject *key_object;
     PyObject *plaintext_object;
     const char *key = NULL;
@@ -67,13 +76,17 @@ static PyObject *pysiphash(PyObject *self, PyObject *args) {
     Py_ssize_t plain_sz;
     uint64_t hash;
 
-    if (!PyArg_ParseTuple(
-            args, "OO:siphash",
-            &key_object, &plaintext_object)) {
+    if (nargs != 2) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "siphash() takes exactly 2 arguments (%zd given)",
+            nargs);
         return NULL;
     }
+    key_object = args[0];
+    plaintext_object = args[1];
 
-    /* Both objects own immutable storage and args keeps them alive. */
+    /* Both objects own immutable storage and remain alive for the call. */
     if (!get_immutable_data(key_object, "key", &key, &key_sz) ||
             !get_immutable_data(
                 plaintext_object,
@@ -122,7 +135,8 @@ static char siphash_docstring[] = ""
     "returns 64-bit output (python Long)\n";
 
 static PyMethodDef siphashc_methods[] = {
-    {"siphash", pysiphash, METH_VARARGS, siphash_docstring},
+    {"siphash", SIPHASHC_PYC_FUNCTION_CAST(pysiphash), METH_FASTCALL,
+     siphash_docstring},
     {NULL, NULL, 0, NULL} /* sentinel */
 };
 

--- a/test_siphashc.py
+++ b/test_siphashc.py
@@ -82,6 +82,23 @@ class TestSiphashC(unittest.TestCase):
             with pytest.raises(TypeError, match="plaintext must be str or bytes"):
                 siphash(b"0123456789ABCDEF", plaintext)
 
+    def test_argument_count(self: TestSiphashC) -> None:
+        """Test positional argument count errors."""
+        for args in ((), (b"key",), (b"key", b"plaintext", b"extra")):
+            with pytest.raises(TypeError) as error:
+                siphash(*args)
+            assert str(error.value) == (
+                f"siphash() takes exactly 2 arguments ({len(args)} given)"
+            )
+
+    def test_rejects_keywords(self: TestSiphashC) -> None:
+        """Test rejection of keyword arguments."""
+        with pytest.raises(
+            TypeError,
+            match=r"siphash\(\) takes no keyword arguments",
+        ):
+            siphash(key=b"0123456789ABCDEF", plaintext=b"a")
+
     @pytest.mark.skipif(
         bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
         reason="requires a GIL-enabled Python",


### PR DESCRIPTION
Avoid tuple construction and generic argument parsing to reduce short-input overhead while preserving existing API behavior.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull requests is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
